### PR TITLE
Add required context keys to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
   server:
     image: sample/directserver
     build:
+      context: ./
       dockerfile: Dockerfile.server
   client:
     image: sample/directclient
     build:
+      context: ./
       dockerfile: Dockerfile.client


### PR DESCRIPTION
I just pulled this down to run it, but `docker-compose up` fails with

```
ERROR: The Compose file is invalid because:
Service server has neither an image nor a build context specified. At least one must be provided.
```

Added the required context values and it works 👍 